### PR TITLE
Removed not necessary public imports 2

### DIFF
--- a/Control/UIAwesomeButton.h
+++ b/Control/UIAwesomeButton.h
@@ -7,7 +7,6 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "NSString+FontAwesome.h"
 #import "UIButton+PPiAwesome.h"
 
 typedef void (^block)();

--- a/Control/UIAwesomeButton.m
+++ b/Control/UIAwesomeButton.m
@@ -7,6 +7,8 @@
 //
 
 #import "UIAwesomeButton.h"
+#import "NSString+FontAwesome.h"
+
 @interface UIAwesomeButton ()
 @property (nonatomic) CGFloat separation;
 @property (nonatomic) NSTextAlignment textAligment;

--- a/Control/UIButton+PPiAwesome.h
+++ b/Control/UIButton+PPiAwesome.h
@@ -7,7 +7,6 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "NSString+FontAwesome.h"
 
 typedef enum {
     IconPositionRight,

--- a/Control/UIButton+PPiAwesome.m
+++ b/Control/UIButton+PPiAwesome.m
@@ -7,6 +7,7 @@
 //
 
 #import "UIButton+PPiAwesome.h"
+#import "NSString+FontAwesome.h"
 #import <QuartzCore/QuartzCore.h>
 #import <objc/runtime.h>
 


### PR DESCRIPTION
#### :tophat: What? Why?

Moving to .m file NSString+FontAwesome imports. No need to expose the dependency on FontAwesome+iOS pod on the header files. Causes collisions. 
#### :ghost: GIF

![](http://i.imgur.com/OvWayte.gif)
